### PR TITLE
More fixes for example2.py

### DIFF
--- a/transparency-in-coverage/python/processors/example2.py
+++ b/transparency-in-coverage/python/processors/example2.py
@@ -19,13 +19,17 @@ log = logging.getLogger('idxutils')
 log.setLevel(logging.DEBUG)
 
 # @rl1987
-if len(sys.argv) == 2:
+if len(sys.argv) >= 2:
     index_loc = sys.argv[1]
 else:
     index_loc = 'https://www.allegiancecosttransparency.com/2022-07-01_LOGAN_HEALTH_index.json'
 
-filename = 'extracted_links.csv'
+filename = 'extracted_links.txt'
+if len(sys.argv) == 3:
+    filename = sys.argv[2]
+
 with open(filename, 'a+') as f:
     for in_network_file in gen_in_network_links(index_loc):
-        f.write(f'{in_network_file},\n')
+        f.write(f'{in_network_file}\n')
         log.info(f'Wrote {in_network_file} to {filename}')
+


### PR DESCRIPTION
* Actually support passing output file name via CLI.
* Refrain from putting comma at the end of each line.