### PR TITLE
Bugfix for last_updated_on value

### DIFF
--- a/transparency-in-coverage/python/mrfutils/mrfutils.py
+++ b/transparency-in-coverage/python/mrfutils/mrfutils.py
@@ -105,7 +105,7 @@ def file_row_from_mixed(
 
 	file_row = dict(
 		filename = filename,
-		last_updated_on = plan_data['last_updated_on']
+		last_updated_on = plan_data.get('last_updated_on')
 	)
 
 	file_row = append_hash(file_row, 'id')


### PR DESCRIPTION
Just changing the dict value retrieval to a .get() in case it doesn't exist