### PR TITLE
Add fix for urls that are queries not paths

### DIFF
--- a/transparency-in-coverage/python/mrfutils/helpers.py
+++ b/transparency-in-coverage/python/mrfutils/helpers.py
@@ -53,6 +53,8 @@ class JSONOpen:
 
 		parsed_url = urlparse(self.filename)
 		self.suffix = ''.join(Path(parsed_url.path).suffixes)
+		if not self.suffix:
+			self.suffix = ''.join(Path(parsed_url.query).suffixes)
 
 		if not (
 			self.suffix.endswith('.json.gz') or


### PR DESCRIPTION
Humana files from the ToC are provided as a query, so if you try and do use the following URL: `https://developers.humana.com/Resource/DownloadPCTFile?fileType=innetwork&fileName=2023-02-19_20_in-network-rates_115029.json.gz`, mrfutils does not recognize it as a json.gz file.

It causes the following exception:
```
exceptions.InvalidMRF: Suffix not JSON: self.filename='https://developers.humana.com/Resource/DownloadPCTFile?fileType=innetwork&fileName=2023-02-19_20_in-network-rates_115029.json.gz' self.suffix=''
```